### PR TITLE
fix: run manual initialization within the app zone

### DIFF
--- a/lib/core/app_starter.dart
+++ b/lib/core/app_starter.dart
@@ -8,30 +8,32 @@ import 'dependency_injection.dart';
 import 'flavors.dart';
 
 Future<void> startApp(Flavor flavor) async {
-  WidgetsFlutterBinding.ensureInitialized();
-
-  getIt.registerSingleton(flavor);
-
-  FlutterError.onError = (details) {
-    log(
-      details.exceptionAsString(),
-      stackTrace: details.stack,
-    );
-  };
-
   runZonedGuarded(
-    () => runApp(
-      flavor == Flavor.prod
-          ? const MyApp()
-          : Directionality(
-              textDirection: TextDirection.ltr,
-              child: Banner(
-                message: flavor.tag,
-                location: BannerLocation.topStart,
-                child: const MyApp(),
+    () {
+      WidgetsFlutterBinding.ensureInitialized();
+
+      getIt.registerSingleton(flavor);
+
+      FlutterError.onError = (details) {
+        log(
+          details.exceptionAsString(),
+          stackTrace: details.stack,
+        );
+      };
+
+      runApp(
+        flavor == Flavor.prod
+            ? const MyApp()
+            : Directionality(
+                textDirection: TextDirection.ltr,
+                child: Banner(
+                  message: flavor.tag,
+                  location: BannerLocation.topStart,
+                  child: const MyApp(),
+                ),
               ),
-            ),
-    ),
+      );
+    },
     (error, stackTrace) => log(
       error.toString(),
       stackTrace: stackTrace,


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

# Description

As described in the Flutter error handling docs, manual initialization must be located inside the app zone. Closes #21.

> Note that if in your app you call WidgetsFlutterBinding.ensureInitialized() manually to perform some initialization before calling runApp (e.g. Firebase.initializeApp()), you must call WidgetsFlutterBinding.ensureInitialized() inside runZonedGuarded

# Type of Change

- 🛠️ Bug fix
