### PR TITLE
refactor: use riverpod as single DI

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This app shows your favorites GitHub repositories. You can search for other repo
 - IDE launch setup:
   - Visual Studio Code
 - Secure app configuration based on a bundled config file (looking for a safer method 🔍).
-- Dependency injection independent of the widgets tree.
+- Directional dependency injection independent of the widgets tree with [riverpod][riverpod_link].
 - Raw OAuth flow implementation with GitHub specifications.
 - ETag-based data caching for basic offline mode support.
 - REST API server integration.
@@ -382,6 +382,7 @@ Submit a [new issue report][new_project_issues_link] if you find any bug or have
 [lumberdash_package_link]: https://pub.dev/packages/lumberdash
 [remove_from_coverage_package_link]: https://pub.dev/packages/remove_from_coverage
 [very_good_cli_package_link]: https://pub.dev/packages/very_good_cli
+[riverpod_link]: https://pub.dev/packages/riverpod
 
 <!-- GitHub documentation -->
 

--- a/lib/core/app_starter.dart
+++ b/lib/core/app_starter.dart
@@ -7,9 +7,11 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lumberdash/lumberdash.dart' as logger;
 
+import '../features/stared_repos/core/dependency_injection.dart'
+    as starred_repos;
 import '../presentation/app.dart';
 import 'config.dart';
-import 'dependency_injection.dart';
+import 'dependency_injection.dart' as core;
 import 'flavors.dart';
 
 Future<void> startApp(Flavor flavor) async {
@@ -39,10 +41,13 @@ Future<void> startApp(Flavor flavor) async {
       );
       final appConfig = AppConfig.fromYamlString(configYamlString);
 
-      final injectionOverrides = await getInjectionOverrides(
-        flavor: flavor,
-        appConfig: appConfig,
-      );
+      final injectionOverrides = [
+        ...await core.getInjectionOverrides(
+          flavor: flavor,
+          appConfig: appConfig,
+        ),
+        ...await starred_repos.getInjectionOverrides(),
+      ];
 
       runApp(
         ProviderScope(

--- a/lib/core/app_starter.dart
+++ b/lib/core/app_starter.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 
 import 'package:emoji_lumberdash/emoji_lumberdash.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:lumberdash/lumberdash.dart' as logger;
 
 import '../presentation/app.dart';
+import 'config.dart';
 import 'dependency_injection.dart';
 import 'flavors.dart';
 
@@ -32,8 +34,14 @@ Future<void> startApp(Flavor flavor) async {
         );
       };
 
+      final configYamlString = await rootBundle.loadString(
+        'assets/config/app_config.${flavor.tag.toLowerCase()}.yaml',
+      );
+      final appConfig = AppConfig.fromYamlString(configYamlString);
+
       final injectionOverrides = await getInjectionOverrides(
         flavor: flavor,
+        appConfig: appConfig,
       );
 
       runApp(

--- a/lib/core/dependency_injection.dart
+++ b/lib/core/dependency_injection.dart
@@ -1,12 +1,38 @@
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../features/auth/core/dependency_injection.dart' as auth;
+import '../features/stared_repos/core/dependency_injection.dart'
+    as starred_repos;
+import '../features/users_placeholder/core/dependency_injection.dart'
+    as users_placeholder;
 import 'config.dart';
 import 'flavors.dart';
 
 final flavorPod = Provider<Flavor>(
-  (_) => Flavor.prod,
+  (_) => throw UnimplementedError(
+    'The app flavor has not been initialized',
+  ),
 );
 
 final appConfigPod = Provider<AppConfig>(
-  (ref) => AppConfig.fromYamlString(''),
+  (_) => throw UnimplementedError(
+    'The app config has not been initialized',
+  ),
 );
+
+Future<List<Override>> getInjectionOverrides({
+  required Flavor flavor,
+}) async {
+  final configYamlString = await rootBundle.loadString(
+    'assets/config/app_config.${flavor.tag.toLowerCase()}.yaml',
+  );
+  final appConfig = AppConfig.fromYamlString(configYamlString);
+  return [
+    flavorPod.overrideWithValue(flavor),
+    appConfigPod.overrideWithValue(appConfig),
+    ...await auth.overrides(),
+    ...await starred_repos.overrides(),
+    ...await users_placeholder.overrides(),
+  ];
+}

--- a/lib/core/dependency_injection.dart
+++ b/lib/core/dependency_injection.dart
@@ -23,16 +23,12 @@ final appConfigPod = Provider<AppConfig>(
 
 Future<List<Override>> getInjectionOverrides({
   required Flavor flavor,
-}) async {
-  final configYamlString = await rootBundle.loadString(
-    'assets/config/app_config.${flavor.tag.toLowerCase()}.yaml',
-  );
-  final appConfig = AppConfig.fromYamlString(configYamlString);
-  return [
-    flavorPod.overrideWithValue(flavor),
-    appConfigPod.overrideWithValue(appConfig),
-    ...await auth.overrides(),
-    ...await starred_repos.overrides(),
-    ...await users_placeholder.overrides(),
-  ];
-}
+  required AppConfig appConfig,
+}) async =>
+    [
+      flavorPod.overrideWithValue(flavor),
+      appConfigPod.overrideWithValue(appConfig),
+      ...await auth.overrides(),
+      ...await starred_repos.overrides(),
+      ...await users_placeholder.overrides(),
+    ];

--- a/lib/core/dependency_injection.dart
+++ b/lib/core/dependency_injection.dart
@@ -10,13 +10,13 @@ import 'config.dart';
 import 'flavors.dart';
 
 final flavorPod = Provider<Flavor>(
-  (_) => throw UnimplementedError(
+  (_) => throw StateError(
     'The app flavor has not been initialized',
   ),
 );
 
 final appConfigPod = Provider<AppConfig>(
-  (_) => throw UnimplementedError(
+  (_) => throw StateError(
     'The app config has not been initialized',
   ),
 );

--- a/lib/core/dependency_injection.dart
+++ b/lib/core/dependency_injection.dart
@@ -1,17 +1,12 @@
-import 'package:get_it/get_it.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'config.dart';
 import 'flavors.dart';
 
-final getIt = GetIt.instance;
+final flavorPod = Provider<Flavor>(
+  (_) => Flavor.prod,
+);
 
-Future<void> injectDependencies({
-  required Flavor flavor,
-  required AppConfig config,
-}) async {
-  getIt.registerSingleton(flavor);
-
-  getIt.registerLazySingleton<AppConfig>(
-    () => config,
-  );
-}
+final appConfigPod = Provider<AppConfig>(
+  (ref) => AppConfig.fromYamlString(''),
+);

--- a/lib/core/dependency_injection.dart
+++ b/lib/core/dependency_injection.dart
@@ -1,11 +1,5 @@
-import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../features/auth/core/dependency_injection.dart' as auth;
-import '../features/stared_repos/core/dependency_injection.dart'
-    as starred_repos;
-import '../features/users_placeholder/core/dependency_injection.dart'
-    as users_placeholder;
 import 'config.dart';
 import 'flavors.dart';
 
@@ -28,7 +22,4 @@ Future<List<Override>> getInjectionOverrides({
     [
       flavorPod.overrideWithValue(flavor),
       appConfigPod.overrideWithValue(appConfig),
-      ...await auth.overrides(),
-      ...await starred_repos.overrides(),
-      ...await users_placeholder.overrides(),
     ];

--- a/lib/core/flavors.dart
+++ b/lib/core/flavors.dart
@@ -1,7 +1,3 @@
-import 'dependency_injection.dart';
-
-Flavor get kAppFlavor => getIt<Flavor>();
-
 enum Flavor {
   dev,
   prod,

--- a/lib/features/auth/core/dependency_injection.dart
+++ b/lib/features/auth/core/dependency_injection.dart
@@ -69,5 +69,3 @@ final authenticatorCubitPod = Provider<AuthenticatorCubit>(
     );
   },
 );
-
-Future<List<Override>> overrides() async => const [];

--- a/lib/features/auth/core/dependency_injection.dart
+++ b/lib/features/auth/core/dependency_injection.dart
@@ -69,3 +69,5 @@ final authenticatorCubitPod = Provider<AuthenticatorCubit>(
     );
   },
 );
+
+Future<List<Override>> overrides() async => const [];

--- a/lib/features/auth/presentation/screens/auth/screen.dart
+++ b/lib/features/auth/presentation/screens/auth/screen.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_my_starred_repos/presentation/routers/app_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:webview_flutter/webview_flutter.dart';
-import 'package:provider/provider.dart';
-
-import '../../../../../presentation/routers/app_router.gr.dart';
 
 part 'widgets/auth_webview.dart';
 

--- a/lib/features/auth/presentation/screens/auth/widgets/auth_webview.dart
+++ b/lib/features/auth/presentation/screens/auth/widgets/auth_webview.dart
@@ -3,7 +3,7 @@ part of '../screen.dart';
 /// {@template AuthWebView}
 /// A widget that wraps a webview used for the auth process.
 /// {@endtemplate}
-class _AuthWebview extends StatefulWidget {
+class _AuthWebview extends ConsumerStatefulWidget {
   /// Creates an auth webview.
   ///
   /// {@macro AuthWebView}
@@ -27,7 +27,7 @@ class _AuthWebview extends StatefulWidget {
   __AuthWebviewState createState() => __AuthWebviewState();
 }
 
-class __AuthWebviewState extends State<_AuthWebview> {
+class __AuthWebviewState extends ConsumerState<_AuthWebview> {
   @override
   void initState() {
     super.initState();
@@ -53,7 +53,7 @@ class __AuthWebviewState extends State<_AuthWebview> {
           final redirectBaseUrl = widget.redirectBaseEndpoint.toString();
           if (navReq.url.startsWith(redirectBaseUrl)) {
             // Returns the obtained redirect endpoint that holds auth data.
-            context.read<AppRouter>().pop(
+            ref.watch(appRouterPod).pop(
                   Uri.parse(navReq.url),
                 );
             return NavigationDecision.prevent;

--- a/lib/features/auth/presentation/screens/login/screen.dart
+++ b/lib/features/auth/presentation/screens/login/screen.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_my_starred_repos/presentation/routers/app_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:material_design_icons_flutter/material_design_icons_flutter.dart';
-import 'package:provider/provider.dart';
 
 import '../../../../../l10n/l10n.dart';
 import '../../../../../presentation/routers/app_router.gr.dart';
@@ -79,12 +80,16 @@ class LoginScreen extends StatelessWidget {
                         constraints: const BoxConstraints(
                           minWidth: _buttonMinWidth,
                         ),
-                        child: ElevatedButton(
-                          style: ElevatedButton.styleFrom(
-                            primary: Colors.green,
+                        child: Consumer(
+                          builder: (context, ref, _) => ElevatedButton(
+                            style: ElevatedButton.styleFrom(
+                              primary: Colors.green,
+                            ),
+                            onPressed: () async => context.logInWithOAuth(
+                              appRouter: ref.watch(appRouterPod),
+                            ),
+                            child: Text(context.loginButtonLabel),
                           ),
-                          onPressed: () async => context.logInWithOAuth(),
-                          child: Text(context.loginButtonLabel),
                         ),
                       ),
                     ),
@@ -99,17 +104,25 @@ class LoginScreen extends StatelessWidget {
 
 /// A [BuildContext] that provides login utilities.
 extension _OAuthContext on BuildContext {
-  Future<void> logInWithOAuth() => read<AuthenticatorCubit>().logIn(
+  Future<void> logInWithOAuth({
+    required AppRouter appRouter,
+  }) =>
+      read<AuthenticatorCubit>().logIn(
         method: LogInMethod.oAuth(
-          callback: _oauthCallback,
+          callback: _oauthCallback(
+            appRouter: appRouter,
+          ),
         ),
       );
 
-  OAuthCallback get _oauthCallback => ({
+  OAuthCallback _oauthCallback({
+    required AppRouter appRouter,
+  }) =>
+      ({
         required Uri authorizationEndpoint,
         required Uri redirectBaseEndpoint,
       }) =>
-          read<AppRouter>().push<Uri>(
+          appRouter.push<Uri>(
             AuthScreenRoute(
               authorizationEndpoint: authorizationEndpoint,
               redirectBaseEndpoint: redirectBaseEndpoint,

--- a/lib/features/counter/presentation/screens/counter/screen.dart
+++ b/lib/features/counter/presentation/screens/counter/screen.dart
@@ -1,17 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_my_starred_repos/core/dependency_injection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../../../core/flavors.dart';
 import '../../../../../l10n/l10n.dart';
 import '../../../../../presentation/widgets/drawer.dart';
 
-class CounterScreen extends StatefulWidget {
+class CounterScreen extends ConsumerStatefulWidget {
   const CounterScreen();
 
   @override
   _CounterScreenState createState() => _CounterScreenState();
 }
 
-class _CounterScreenState extends State<CounterScreen> {
+class _CounterScreenState extends ConsumerState<CounterScreen> {
   int _counter = 0;
 
   void _incrementCounter() => setState(
@@ -23,6 +25,7 @@ class _CounterScreenState extends State<CounterScreen> {
   @override
   Widget build(BuildContext context) {
     final l10n = context.l10n;
+    final flavor = ref.watch(flavorPod);
     return Scaffold(
       appBar: AppBar(
         title: Text(l10n.counterScreenTitle),
@@ -34,11 +37,11 @@ class _CounterScreenState extends State<CounterScreen> {
           children: <Widget>[
             Center(
               child: Image.asset(
-                'assets/app_icon/${kAppFlavor.tag.toLowerCase()}-icon.512.png',
+                'assets/app_icon/${flavor.tag.toLowerCase()}-icon.512.png',
               ),
             ),
             Text(
-              '${kAppFlavor.tag} flavor',
+              '${flavor.tag} flavor',
             ),
             Text(l10n.currentCountMessage(_counter)),
             Text(

--- a/lib/features/stared_repos/core/dependency_injection.dart
+++ b/lib/features/stared_repos/core/dependency_injection.dart
@@ -91,7 +91,7 @@ final starredReposCubitPod = Provider<StarredReposCubit>(
   },
 );
 
-Future<List<Override>> overrides() async {
+Future<List<Override>> getInjectionOverrides() async {
   final dbDir = await getApplicationDocumentsDirectory();
   await dbDir.create(recursive: true);
   final dbPath = path.join(dbDir.path, 'my_database.db');

--- a/lib/features/stared_repos/core/dependency_injection.dart
+++ b/lib/features/stared_repos/core/dependency_injection.dart
@@ -1,12 +1,8 @@
 import 'package:dio/dio.dart';
-import 'package:meta/meta.dart';
-import 'package:path/path.dart' as path;
-import 'package:path_provider/path_provider.dart';
+import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:sembast/sembast.dart';
-import 'package:sembast/sembast_io.dart';
 
-import '../../../core/dependency_injection.dart';
-import '../../auth/infrastructure/external/dio_interceptors.dart';
 import '../application/starred_repos_cubit/cubit.dart';
 import '../infrastructure/data_sources/etags_lds/interface.dart';
 import '../infrastructure/data_sources/etags_lds/sembast_implementation.dart';
@@ -18,67 +14,72 @@ import '../infrastructure/external/etags_dio_interceptor.dart';
 import '../infrastructure/facades/starred_repos_repo/implementation.dart';
 import '../infrastructure/facades/starred_repos_repo/interface.dart';
 
-@visibleForTesting
-const starredRepoDioName = 'starred_repos_dio';
+final sembastDbPod = Provider<Database?>((_) => null);
 
-/// Injects all instances required for starred repos funcionality.
-Future<void> injectDependencies() async {
-  // Setup
-  final dbDir = await getApplicationDocumentsDirectory();
-  await dbDir.create(recursive: true);
-  final dbPath = path.join(dbDir.path, 'my_database.db');
-  final db = await databaseFactoryIo.openDatabase(dbPath);
+final pagesEtagsLDSPod = Provider<PagesEtagsLDS>(
+  (ref) {
+    final sembastDb = ref.watch(sembastDbPod)!;
+    return PagesEtagsLDSImp(
+      sembastDatabase: sembastDb,
+    );
+  },
+);
 
-  // External
-  getIt.registerLazySingleton<EtagsInterceptor>(
-    () => EtagsInterceptor(
-      pagesEtagsLDS: getIt(),
-    ),
-  );
-  getIt.registerLazySingleton<Database>(
-    () => db,
-  );
-  getIt.registerLazySingleton(
-    () => Dio()
+final etagsInterceptorPod = Provider<EtagsInterceptor>(
+  (ref) {
+    final pagesEtagsLDS = ref.watch(pagesEtagsLDSPod);
+    return EtagsInterceptor(
+      pagesEtagsLDS: pagesEtagsLDS,
+    );
+  },
+);
+
+final starredReposDioPod = Provider<Dio>(
+  (ref) {
+    final authInterceptor = ref.watch(authInterceptorPod);
+    final etagsInterceptor = ref.watch(etagsInterceptorPod);
+    return Dio()
       ..interceptors.addAll([
-        getIt<AuthInterceptor>(),
-        getIt<EtagsInterceptor>(),
-      ]),
-    instanceName: starredRepoDioName,
-  );
+        authInterceptor,
+        etagsInterceptor,
+      ]);
+  },
+);
 
-  // Data sources
-  getIt.registerLazySingleton<PagesEtagsLDS>(
-    () => PagesEtagsLDSImp(
-      sembastDatabase: getIt(),
-    ),
-  );
-  getIt.registerLazySingleton<StarredReposLDS>(
-    () => StarredReposLDSImp(
-      sembastDatabase: getIt(),
-    ),
-  );
+final starredReposRDSPod = Provider<StaredReposRDS>(
+  (ref) {
+    final dio = ref.watch(starredReposDioPod);
+    return StaredReposRDSImp(
+      dio: dio,
+    );
+  },
+);
 
-  getIt.registerLazySingleton<StaredReposRDS>(
-    () => StaredReposRDSImp(
-      dio: getIt(
-        instanceName: starredRepoDioName,
-      ),
-    ),
-  );
+final starredReposLDSPod = Provider<StarredReposLDS>(
+  (ref) {
+    final sembastDb = ref.watch(sembastDbPod)!;
+    return StarredReposLDSImp(
+      sembastDatabase: sembastDb,
+    );
+  },
+);
 
-  // Facades
-  getIt.registerLazySingleton<StarredReposRepo>(
-    () => StarredReposRepoImp(
-      starredReposRDS: getIt(),
-      starredReposLDS: getIt(),
-    ),
-  );
+final starredReposRepoPod = Provider<StarredReposRepo>(
+  (ref) {
+    final starredReposLDS = ref.watch(starredReposLDSPod);
+    final starredReposRDS = ref.watch(starredReposRDSPod);
+    return StarredReposRepoImp(
+      starredReposRDS: starredReposRDS,
+      starredReposLDS: starredReposLDS,
+    );
+  },
+);
 
-  // State managers
-  getIt.registerFactory(
-    () => StarredReposCubit(
-      starredReposRepo: getIt(),
-    ),
-  );
-}
+final starredReposCubitPod = Provider<StarredReposCubit>(
+  (ref) {
+    final starredReposRepo = ref.watch(starredReposRepoPod);
+    return StarredReposCubit(
+      starredReposRepo: starredReposRepo,
+    );
+  },
+);

--- a/lib/features/stared_repos/core/dependency_injection.dart
+++ b/lib/features/stared_repos/core/dependency_injection.dart
@@ -1,8 +1,11 @@
 import 'package:dio/dio.dart';
-import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:path/path.dart' as path;
+import 'package:path_provider/path_provider.dart';
 import 'package:sembast/sembast.dart';
+import 'package:sembast/sembast_io.dart';
 
+import '../../auth/core/dependency_injection.dart';
 import '../application/starred_repos_cubit/cubit.dart';
 import '../infrastructure/data_sources/etags_lds/interface.dart';
 import '../infrastructure/data_sources/etags_lds/sembast_implementation.dart';
@@ -14,11 +17,15 @@ import '../infrastructure/external/etags_dio_interceptor.dart';
 import '../infrastructure/facades/starred_repos_repo/implementation.dart';
 import '../infrastructure/facades/starred_repos_repo/interface.dart';
 
-final sembastDbPod = Provider<Database?>((_) => null);
+final sembastDbPod = Provider<Database>(
+  (_) => throw UnimplementedError(
+    'The Sembast database has not been initialized',
+  ),
+);
 
 final pagesEtagsLDSPod = Provider<PagesEtagsLDS>(
   (ref) {
-    final sembastDb = ref.watch(sembastDbPod)!;
+    final sembastDb = ref.watch(sembastDbPod);
     return PagesEtagsLDSImp(
       sembastDatabase: sembastDb,
     );
@@ -57,7 +64,7 @@ final starredReposRDSPod = Provider<StaredReposRDS>(
 
 final starredReposLDSPod = Provider<StarredReposLDS>(
   (ref) {
-    final sembastDb = ref.watch(sembastDbPod)!;
+    final sembastDb = ref.watch(sembastDbPod);
     return StarredReposLDSImp(
       sembastDatabase: sembastDb,
     );
@@ -83,3 +90,14 @@ final starredReposCubitPod = Provider<StarredReposCubit>(
     );
   },
 );
+
+Future<List<Override>> overrides() async {
+  final dbDir = await getApplicationDocumentsDirectory();
+  await dbDir.create(recursive: true);
+  final dbPath = path.join(dbDir.path, 'my_database.db');
+  final sembastDb = await databaseFactoryIo.openDatabase(dbPath);
+
+  return [
+    sembastDbPod.overrideWithValue(sembastDb),
+  ];
+}

--- a/lib/features/stared_repos/core/dependency_injection.dart
+++ b/lib/features/stared_repos/core/dependency_injection.dart
@@ -18,7 +18,7 @@ import '../infrastructure/facades/starred_repos_repo/implementation.dart';
 import '../infrastructure/facades/starred_repos_repo/interface.dart';
 
 final sembastDbPod = Provider<Database>(
-  (_) => throw UnimplementedError(
+  (_) => throw StateError(
     'The Sembast database has not been initialized',
   ),
 );

--- a/lib/features/stared_repos/presentation/screens/starred_repos/screen.dart
+++ b/lib/features/stared_repos/presentation/screens/starred_repos/screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_my_starred_repos/features/stared_repos/core/dependency_injection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../../core/dependency_injection.dart';
 import '../../../application/starred_repos_cubit/cubit.dart';
 
 part 'wrapper.dart';

--- a/lib/features/stared_repos/presentation/screens/starred_repos/wrapper.dart
+++ b/lib/features/stared_repos/presentation/screens/starred_repos/wrapper.dart
@@ -2,7 +2,7 @@ part of 'screen.dart';
 
 /// A wrapper widget that injects the required elements for the
 /// [StarredReposScreen] to work.
-class _Wrapper extends StatelessWidget {
+class _Wrapper extends ConsumerWidget {
   /// Creates a [StarredReposScreen] wrapper widget.
   ///
   /// The actual screen content should be built within the [builder].
@@ -14,12 +14,15 @@ class _Wrapper extends StatelessWidget {
   final WidgetBuilder builder;
 
   @override
-  Widget build(BuildContext context) => MultiProvider(
-        providers: [
-          BlocProvider<StarredReposCubit>(
-            create: (context) => getIt()..load(),
-          ),
-        ],
-        builder: (context, child) => builder(context),
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final starredReposCubit = ref.watch(starredReposCubitPod);
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<StarredReposCubit>.value(
+          value: starredReposCubit..load(),
+        ),
+      ],
+      child: Builder(builder: builder),
+    );
+  }
 }

--- a/lib/features/users_placeholder/core/dependency_injection.dart
+++ b/lib/features/users_placeholder/core/dependency_injection.dart
@@ -68,5 +68,3 @@ final usersCubitPod = Provider<UsersCubit>(
     );
   },
 );
-
-Future<List<Override>> overrides() async => const [];

--- a/lib/features/users_placeholder/core/dependency_injection.dart
+++ b/lib/features/users_placeholder/core/dependency_injection.dart
@@ -68,3 +68,5 @@ final usersCubitPod = Provider<UsersCubit>(
     );
   },
 );
+
+Future<List<Override>> overrides() async => const [];

--- a/lib/features/users_placeholder/presentation/screens/users/screen.dart
+++ b/lib/features/users_placeholder/presentation/screens/users/screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_my_starred_repos/features/users_placeholder/core/dependency_injection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../../core/dependency_injection.dart';
 import '../../../../../l10n/l10n.dart';
 import '../../../../../presentation/widgets/drawer.dart';
 import '../../../application/users_cubit/cubit.dart';

--- a/lib/features/users_placeholder/presentation/screens/users/wrapper.dart
+++ b/lib/features/users_placeholder/presentation/screens/users/wrapper.dart
@@ -1,6 +1,6 @@
 part of 'screen.dart';
 
-class Wrapper extends StatelessWidget {
+class Wrapper extends ConsumerWidget {
   const Wrapper({
     Key? key,
     required this.builder,
@@ -9,12 +9,17 @@ class Wrapper extends StatelessWidget {
   final WidgetBuilder builder;
 
   @override
-  Widget build(BuildContext context) => MultiProvider(
-        providers: [
-          BlocProvider<UsersCubit>(
-            create: (context) => getIt()..load(),
-          ),
-        ],
-        builder: (context, child) => builder(context),
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final usersCubit = ref.watch(usersCubitPod);
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<UsersCubit>.value(
+          value: usersCubit..load(),
+        ),
+      ],
+      child: Builder(
+        builder: builder,
+      ),
+    );
+  }
 }

--- a/lib/presentation/app.dart
+++ b/lib/presentation/app.dart
@@ -1,52 +1,59 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
+import 'package:flutter_my_starred_repos/presentation/routers/app_router.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../core/dependency_injection.dart';
 import '../core/flavors.dart';
 import '../features/auth/application/authenticator_cubit/authenticator_cubit.dart';
 import 'routers/app_router.gr.dart';
 
-class MyApp extends StatelessWidget {
+class MyApp extends ConsumerWidget {
   const MyApp();
 
   @override
-  Widget build(BuildContext context) => MultiProvider(
-        providers: [
-          ListenableProvider<AppRouter>(
-            create: (context) => AppRouter(),
-          ),
-          BlocProvider(
-            create: (context) => getIt<AuthenticatorCubit>()..checkAuthStatus(),
-          ),
-        ],
-        builder: (context, _) =>
-            BlocListener<AuthenticatorCubit, AuthenticatorState>(
-          listener: (context, authenticatorState) {
-            authenticatorState.maybeWhen(
-              authenticated: () => context.read<AppRouter>().pushAndPopUntil(
-                    const CounterScreenRoute(),
-                    predicate: (route) => false,
-                  ),
-              unauthenticated: () => context.read<AppRouter>().pushAndPopUntil(
-                    const LoginScreenRoute(),
-                    predicate: (route) => false,
-                  ),
-              orElse: () {},
-            );
-          },
-          child: MaterialApp.router(
-            title: 'App (${kAppFlavor.tag})',
-            theme: ThemeData(
-              primarySwatch: Colors.blue,
+  Widget build(BuildContext context, WidgetRef ref) {
+    final authenticatorCubit = ref.watch(authenticatorCubitPod);
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthenticatorCubit>.value(
+          value: authenticatorCubit..checkAuthStatus(),
+        ),
+      ],
+      child: Builder(
+        builder: (context) => Consumer(
+          builder: (context, ref, _) =>
+              BlocListener<AuthenticatorCubit, AuthenticatorState>(
+            listener: (context, authenticatorState) {
+              final appRouter = ref.watch(appRouterPod);
+              authenticatorState.maybeWhen(
+                authenticated: () => appRouter.pushAndPopUntil(
+                  const CounterScreenRoute(),
+                  predicate: (route) => false,
+                ),
+                unauthenticated: () => appRouter.pushAndPopUntil(
+                  const LoginScreenRoute(),
+                  predicate: (route) => false,
+                ),
+                orElse: () {},
+              );
+            },
+            child: MaterialApp.router(
+              title: 'App (${ref.watch(flavorPod).tag})',
+              theme: ThemeData(
+                primarySwatch: Colors.blue,
+              ),
+              localizationsDelegates: AppLocalizations.localizationsDelegates,
+              supportedLocales: AppLocalizations.supportedLocales,
+              routerDelegate: ref.watch(appRouterPod).delegate(),
+              routeInformationParser:
+                  ref.watch(appRouterPod).defaultRouteParser(),
             ),
-            localizationsDelegates: AppLocalizations.localizationsDelegates,
-            supportedLocales: AppLocalizations.supportedLocales,
-            routerDelegate: context.read<AppRouter>().delegate(),
-            routeInformationParser:
-                context.read<AppRouter>().defaultRouteParser(),
           ),
         ),
-      );
+      ),
+    );
+  }
 }

--- a/lib/presentation/routers/app_router.dart
+++ b/lib/presentation/routers/app_router.dart
@@ -1,11 +1,13 @@
 import 'package:auto_route/annotations.dart';
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../features/auth/presentation/screens/auth/screen.dart';
 import '../../features/auth/presentation/screens/login/screen.dart';
 import '../../features/counter/presentation/screens/counter/screen.dart';
 import '../../features/stared_repos/presentation/screens/starred_repos/screen.dart';
 import '../../features/users_placeholder/presentation/screens/users/screen.dart';
+import 'app_router.gr.dart';
 
 @CustomAutoRouter(
   routes: [
@@ -28,3 +30,7 @@ import '../../features/users_placeholder/presentation/screens/users/screen.dart'
   ],
 )
 class $AppRouter {}
+
+final appRouterPod = ChangeNotifierProvider<AppRouter>(
+  (_) => AppRouter(),
+);

--- a/lib/presentation/widgets/drawer.dart
+++ b/lib/presentation/widgets/drawer.dart
@@ -1,15 +1,15 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
+import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../features/auth/application/authenticator_cubit/authenticator_cubit.dart';
 import '../routers/app_router.gr.dart';
 
-class AppDrawer extends StatelessWidget {
+class AppDrawer extends ConsumerWidget {
   const AppDrawer({Key? key}) : super(key: key);
 
   @override
-  Widget build(BuildContext context) => Drawer(
+  Widget build(BuildContext context, WidgetRef ref) => Drawer(
         child: ListView(
           children: <Widget>[
             // TODO: Add translations.
@@ -42,7 +42,7 @@ class AppDrawer extends StatelessWidget {
                 ListTile(
                   leading: const Icon(Icons.logout),
                   title: const Text('Log out'),
-                  onTap: () => context.read<AuthenticatorCubit>().logOut(),
+                  onTap: () => ref.watch(authenticatorCubitPod).logOut(),
                 ),
               ],
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -284,6 +284,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_riverpod:
+    dependency: "direct main"
+    description:
+      name: flutter_riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.6"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -317,13 +324,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  get_it:
-    dependency: "direct main"
-    description:
-      name: get_it
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "6.1.1"
   glob:
     dependency: transitive
     description:
@@ -633,7 +633,7 @@ packages:
     source: hosted
     version: "4.2.1"
   provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: provider
       url: "https://pub.dartlang.org"
@@ -653,6 +653,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  riverpod:
+    dependency: transitive
+    description:
+      name: riverpod
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0-dev.6"
   rxdart:
     dependency: transitive
     description:
@@ -735,6 +742,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
+  state_notifier:
+    dependency: transitive
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.0"
   stream_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,8 +18,7 @@ dependencies:
   oauth2: ^2.0.0
 
   # Dependency injection
-  get_it: ^6.1.1
-  provider: ^5.0.0
+  flutter_riverpod: ^1.0.0-dev.6
 
   # Functional programming
   dartz: ^0.10.0-nullsafety.2

--- a/test/core/dependency_injection_test.dart
+++ b/test/core/dependency_injection_test.dart
@@ -1,69 +1,135 @@
 import 'package:flutter_my_starred_repos/core/config.dart';
 import 'package:flutter_my_starred_repos/core/dependency_injection.dart';
 import 'package:flutter_my_starred_repos/core/flavors.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:test/test.dart';
 
 void main() {
   group(
     '''
 
-GIVEN an injector function
-AND the app config data''',
+GIVEN a depencencies container''',
     () {
-      // ARRANGE
-      const appConfig = AppConfig(
-        githubAuthConfig: GithubAuthConfig(
-          clientId: 'clientId',
-          clientSecret: 'clientSecret',
-        ),
+      test(
+        '''
+
+AND no interaction
+WHEN the app flavor is accessed
+THEN an exception is thrown
+├─ THAT indicates that the flavor has not been initialized
+''',
+        () {
+          // ARRANGE
+          final container = ProviderContainer();
+
+          // ACT
+          Flavor action() => container.read(flavorPod);
+
+          // ASSERT
+          expect(
+            action,
+            throwsA(
+              predicate(
+                (e) => e is ProviderException && e.exception is StateError,
+              ),
+            ),
+          );
+        },
       );
 
-      for (final flavor in Flavor.values) {
-        group(
-          '''
-  
-AND the ${flavor.tag} flavor
-WHEN the injection process is triggered''',
-          () {
-            setUp(
-              () async {
-                // ARRANGE
-                getIt.reset();
+      test(
+        '''
 
-                // ACT
-                await injectDependencies(
-                  config: appConfig,
-                  flavor: flavor,
+AND no interaction
+WHEN the app config is accessed
+THEN an exception is thrown
+├─ THAT indicates that the config has not been initialized
+''',
+        () {
+          // ARRANGE
+          final container = ProviderContainer();
+
+          // ACT
+          AppConfig action() => container.read(appConfigPod);
+
+          // ASSERT
+          expect(
+            action,
+            throwsA(
+              predicate(
+                (e) => e is ProviderException && e.exception is StateError,
+              ),
+            ),
+          );
+        },
+      );
+
+      group(
+        '''
+
+AND an injection overrides getter function''',
+        () {
+          // ARRANGE
+          for (final flavor in Flavor.values) {
+            group(
+              '''
+
+AND the ${flavor.tag} flavor
+AND the ${flavor.tag} app config
+WHEN the injection process is triggered''',
+              () {
+                // ARRANGE
+                final appConfig = AppConfig(
+                  githubAuthConfig: GithubAuthConfig(
+                    clientId: 'clientId-${flavor.tag}',
+                    clientSecret: 'clientSecret-${flavor.tag}',
+                  ),
+                );
+                late ProviderContainer container;
+                setUp(
+                  () async {
+                    final overrides = await getInjectionOverrides(
+                      flavor: flavor,
+                      appConfig: appConfig,
+                    );
+                    container = ProviderContainer(
+                      overrides: overrides,
+                    );
+                  },
+                );
+
+                test(
+                  '''
+
+THEN the ${flavor.tag} flavor should be initialized
+''',
+                  () async {
+                    // ACT
+                    final result = container.read(flavorPod);
+
+                    // ASSERT
+                    expect(result, flavor);
+                  },
+                );
+
+                test(
+                  '''
+
+THEN the app config should be initialized
+''',
+                  () async {
+                    // ACT
+                    final result = container.read(appConfigPod);
+
+                    // ASSERT
+                    expect(result, appConfig);
+                  },
                 );
               },
             );
-
-            test(
-              '''
-
-THEN the flavor should be injected
-''',
-              () async {
-                // ASSERT
-                expect(getIt.isRegistered<Flavor>(), isTrue);
-                expect(kAppFlavor, flavor);
-              },
-            );
-
-            test(
-              '''
-
-THEN the app config should be injected
-''',
-              () async {
-                // ASSERT
-                final registeredAppConfig = getIt<AppConfig>();
-                expect(registeredAppConfig, appConfig);
-              },
-            );
-          },
-        );
-      }
+          }
+        },
+      );
     },
   );
 }

--- a/test/core/dependency_injection_test.dart
+++ b/test/core/dependency_injection_test.dart
@@ -64,72 +64,68 @@ THEN an exception is thrown
         },
       );
 
-      group(
-        '''
-
-AND an injection overrides getter function''',
-        () {
-          // ARRANGE
-          for (final flavor in Flavor.values) {
-            group(
-              '''
-
+      // ARRANGE
+      for (final flavor in Flavor.values) {
+        group(
+          '''
+AND an injection overrides getter function
+├─ THAT overrides the flavor injection
+├─ AND  overrides the app config injection
 AND the ${flavor.tag} flavor
 AND the ${flavor.tag} app config
 WHEN the injection process is triggered''',
-              () {
-                // ARRANGE
-                final appConfig = AppConfig(
-                  githubAuthConfig: GithubAuthConfig(
-                    clientId: 'clientId-${flavor.tag}',
-                    clientSecret: 'clientSecret-${flavor.tag}',
-                  ),
+          () {
+            // ARRANGE
+            final appConfig = AppConfig(
+              githubAuthConfig: GithubAuthConfig(
+                clientId: 'clientId-${flavor.tag}',
+                clientSecret: 'clientSecret-${flavor.tag}',
+              ),
+            );
+            late ProviderContainer container;
+            setUp(
+              () async {
+                // ACT
+                final overrides = await getInjectionOverrides(
+                  flavor: flavor,
+                  appConfig: appConfig,
                 );
-                late ProviderContainer container;
-                setUp(
-                  () async {
-                    final overrides = await getInjectionOverrides(
-                      flavor: flavor,
-                      appConfig: appConfig,
-                    );
-                    container = ProviderContainer(
-                      overrides: overrides,
-                    );
-                  },
-                );
-
-                test(
-                  '''
-
-THEN the ${flavor.tag} flavor should be initialized
-''',
-                  () async {
-                    // ACT
-                    final result = container.read(flavorPod);
-
-                    // ASSERT
-                    expect(result, flavor);
-                  },
-                );
-
-                test(
-                  '''
-
-THEN the app config should be initialized
-''',
-                  () async {
-                    // ACT
-                    final result = container.read(appConfigPod);
-
-                    // ASSERT
-                    expect(result, appConfig);
-                  },
+                container = ProviderContainer(
+                  overrides: overrides,
                 );
               },
             );
-          }
-        },
-      );
+
+            test(
+              '''
+
+THEN the ${flavor.tag} flavor should be initialized
+''',
+              () async {
+                // ACT
+                final result = container.read(flavorPod);
+
+                // ASSERT
+                expect(result, flavor);
+              },
+            );
+
+            test(
+              '''
+
+THEN the app config should be initialized
+''',
+              () async {
+                // ACT
+                final result = container.read(appConfigPod);
+
+                // ASSERT
+                expect(result, appConfig);
+              },
+            );
+          },
+        );
+      }
     },
   );
 }

--- a/test/features/auth/core/dependency_injection_test.dart
+++ b/test/features/auth/core/dependency_injection_test.dart
@@ -1,27 +1,27 @@
 import 'package:flutter_my_starred_repos/core/config.dart';
+import 'package:flutter_my_starred_repos/core/dependency_injection.dart';
 import 'package:flutter_my_starred_repos/features/auth/application/authenticator_cubit/authenticator_cubit.dart';
 import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
 import 'package:flutter_my_starred_repos/features/auth/infrastructure/data_sources/authenticator/interface.dart';
 import 'package:flutter_my_starred_repos/features/auth/infrastructure/external/dio_interceptors.dart';
 import 'package:flutter_my_starred_repos/features/auth/infrastructure/facades/auth_service/interface.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:get_it/get_it.dart';
 import 'package:test/test.dart';
 
 void main() {
   group(
     '''
 
-GIVEN an injector function
+GIVEN a dependencies container
 AND a previously injected app config
 WHEN the injection process is triggered''',
     () {
-      final getIt = GetIt.instance;
+      late ProviderContainer container;
 
       setUp(
         () async {
           // ARRANGE
-          await getIt.reset();
           const githubAuthConfig = GithubAuthConfig(
             clientId: 'clientId',
             clientSecret: 'clientSecret',
@@ -29,15 +29,19 @@ WHEN the injection process is triggered''',
           const appConfig = AppConfig(
             githubAuthConfig: githubAuthConfig,
           );
-          getIt.registerLazySingleton(() => appConfig);
 
           // ACT
-          await injectDependencies();
+          container = ProviderContainer(
+            overrides: [
+              appConfigPod.overrideWithValue(appConfig),
+            ],
+          );
         },
       );
+
       test(
         '''
-  
+
 THEN the necessary auth dependencies should be injected
 ├─ BY  injecting a single GitHub auth config
 ├─ AND injecting a single Flutter secure storage
@@ -49,27 +53,27 @@ THEN the necessary auth dependencies should be injected
         () async {
           // ASSERT
           expect(
-            getIt<GithubAuthConfig>(),
-            getIt<GithubAuthConfig>(),
+            container.read(githubAuthConfigPod),
+            isA<GithubAuthConfig>(),
           );
           expect(
-            getIt<FlutterSecureStorage>(),
-            getIt<FlutterSecureStorage>(),
+            container.read(flutterSecureStoragePod),
+            isA<FlutterSecureStorage>(),
           );
           expect(
-            getIt<AuthInterceptor>(),
-            getIt<AuthInterceptor>(),
+            container.read(authInterceptorPod),
+            isA<AuthInterceptor>(),
           );
           expect(
-            getIt<Authenticator>(),
-            getIt<Authenticator>(),
+            container.read(authenticatorPod),
+            isA<Authenticator>(),
           );
           expect(
-            getIt<AuthService>(),
-            getIt<AuthService>(),
+            container.read(authServicePod),
+            isA<AuthService>(),
           );
           expect(
-            getIt<AuthenticatorCubit>(),
+            container.read(authenticatorCubitPod),
             isA<AuthenticatorCubit>(),
           );
         },

--- a/test/features/stared_repos/core/dependency_injection_test.dart
+++ b/test/features/stared_repos/core/dependency_injection_test.dart
@@ -1,13 +1,19 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_my_starred_repos/features/auth/core/dependency_injection.dart';
 import 'package:flutter_my_starred_repos/features/auth/infrastructure/external/dio_interceptors.dart';
 import 'package:flutter_my_starred_repos/features/stared_repos/application/starred_repos_cubit/cubit.dart';
 import 'package:flutter_my_starred_repos/features/stared_repos/core/dependency_injection.dart';
+import 'package:flutter_my_starred_repos/features/stared_repos/infrastructure/data_sources/etags_lds/interface.dart';
 import 'package:flutter_my_starred_repos/features/stared_repos/infrastructure/data_sources/stared_repos_rds/interface.dart';
 import 'package:flutter_my_starred_repos/features/stared_repos/infrastructure/data_sources/starred_repos_lds/interface.dart';
+import 'package:flutter_my_starred_repos/features/stared_repos/infrastructure/external/etags_dio_interceptor.dart';
 import 'package:flutter_my_starred_repos/features/stared_repos/infrastructure/facades/starred_repos_repo/interface.dart';
-import 'package:get_it/get_it.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:sembast/sembast.dart';
 import 'package:test/test.dart';
+
+class MockSembastDb extends Mock implements Database {}
 
 class MockAuthInterceptor extends Fake implements AuthInterceptor {}
 
@@ -15,56 +21,111 @@ void main() {
   group(
     '''
 
-GIVEN an injector function
-AND a previously injected auth interceptor
-WHEN the injection process is triggered''',
+GIVEN a depencencies container''',
     () {
-      final getIt = GetIt.instance;
-
-      setUp(
-        () async {
-          // ARRANGE
-          await getIt.reset();
-          getIt.registerLazySingleton<AuthInterceptor>(
-            () => MockAuthInterceptor(),
-          );
-
-          // ACT
-          await injectDependencies();
-        },
-      );
       test(
         '''
 
-THEN the necessary starred-repos-related dependencies should be injected
-├─ BY  injecting a single Dio HTTP client
-│  ├─ THAT is identified by its instance name
-├─ AND injecting a single starred repos local data source
-├─ AND injecting a single starred repos remote data source
-├─ AND injecting a single starred repos repository
-├─ AND injecting a starred repos cubit factory
+AND no interaction
+WHEN the Sembast database is accessed
+THEN an exception is thrown
+├─ THAT indicates that the database has not been initialized
 ''',
-        () async {
+        () {
+          // ARRANGE
+          final container = ProviderContainer();
+
+          // ACT
+          Database action() => container.read(sembastDbPod);
+
           // ASSERT
           expect(
-            getIt<Dio>(instanceName: starredRepoDioName),
-            getIt<Dio>(instanceName: starredRepoDioName),
+            action,
+            throwsA(
+              predicate(
+                (e) => e is ProviderException && e.exception is StateError,
+              ),
+            ),
           );
-          expect(
-            getIt<StarredReposLDS>(),
-            getIt<StarredReposLDS>(),
+        },
+      );
+
+      group(
+        '''
+
+AND a previously injected auth interceptor
+AND an injection overrides getter function
+├─ THAT overrides the Sembast database injection
+WHEN the injection process is triggered''',
+        () {
+          // ARRANGE
+          late ProviderContainer container;
+
+          setUp(
+            () async {
+              // ARRANGE
+              final preconditionalOverrides = [
+                authInterceptorPod.overrideWithValue(MockAuthInterceptor()),
+              ];
+              // ACT
+              final overrides = await getInjectionOverrides();
+              container = ProviderContainer(
+                overrides: [
+                  ...preconditionalOverrides,
+                  ...overrides,
+                ],
+              );
+            },
           );
-          expect(
-            getIt<StaredReposRDS>(),
-            getIt<StaredReposRDS>(),
-          );
-          expect(
-            getIt<StarredReposRepo>(),
-            getIt<StarredReposRepo>(),
-          );
-          expect(
-            getIt<StarredReposCubit>(),
-            isA<StarredReposCubit>(),
+
+          test(
+            '''
+
+THEN the necessary starred-repos-related dependencies should be injected
+├─ BY  injecting a single Sembast database
+├─ AND injecting a single pages ETags local data source
+├─ AND injecting a single ETags interceptor
+├─ AND injecting a single Dio HTTP client
+├─ AND injecting a single starred repos remote data source
+├─ AND injecting a single starred repos local data source
+├─ AND injecting a single starred repos repository
+├─ AND injecting a single starred repos cubit
+''',
+            () async {
+              // ASSERT
+              expect(
+                container.read(sembastDbPod),
+                isA<Database>(),
+              );
+              expect(
+                container.read(pagesEtagsLDSPod),
+                isA<PagesEtagsLDS>(),
+              );
+              expect(
+                container.read(etagsInterceptorPod),
+                isA<EtagsInterceptor>(),
+              );
+              expect(
+                container.read(starredReposDioPod),
+                isA<Dio>(),
+              );
+              expect(
+                container.read(starredReposRDSPod),
+                isA<StaredReposRDS>(),
+              );
+              expect(
+                container.read(starredReposLDSPod),
+                isA<StarredReposLDS>(),
+              );
+              expect(
+                container.read(starredReposRepoPod),
+                isA<StarredReposRepo>(),
+              );
+              expect(
+                container.read(starredReposCubitPod),
+                isA<StarredReposCubit>(),
+              );
+            },
           );
         },
       );

--- a/test/features/users_placeholder/core/dependency_injection_test.dart
+++ b/test/features/users_placeholder/core/dependency_injection_test.dart
@@ -1,93 +1,111 @@
 import 'package:dio/dio.dart';
+import 'package:flutter_my_starred_repos/core/dependency_injection.dart';
 import 'package:flutter_my_starred_repos/core/flavors.dart';
 import 'package:flutter_my_starred_repos/features/users_placeholder/application/users_cubit/cubit.dart';
 import 'package:flutter_my_starred_repos/features/users_placeholder/core/dependency_injection.dart';
-import 'package:flutter_my_starred_repos/features/users_placeholder/infrastructure/data_sources/users_rds/interface.dart';
+import 'package:flutter_my_starred_repos/features/users_placeholder/infrastructure/data_sources/users_rds/gql_implementation.dart'
+    as gql;
+import 'package:flutter_my_starred_repos/features/users_placeholder/infrastructure/data_sources/users_rds/rest_implementation.dart'
+    as rest;
 import 'package:flutter_my_starred_repos/features/users_placeholder/infrastructure/facades/interface.dart';
-import 'package:get_it/get_it.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:test/test.dart';
 import 'package:graphql/client.dart';
 
 void main() {
-  group(
-    '''
-  
-GIVEN an injector function''',
-    () {
-      // ARRANGE
-      final getIt = GetIt.instance;
+  // ARRANGE
+  for (final flavor in Flavor.values) {
+    group(
+      '''
 
-      for (final flavor in Flavor.values) {
-        group(
-          '''
-  
-AND the ${flavor.tag} flavor
+GIVEN a depencencies container
+AND a previously injected ${flavor.tag} flavor
 WHEN the injection process is triggered''',
-          () {
-            setUp(
-              () async {
-                // ARRANGE
-                getIt.reset();
+      () {
+        // ARRANGE
+        late ProviderContainer container;
 
-                // ACT
-                await injectDependencies(
-                  flavor: flavor,
+        setUp(
+          () async {
+            // ARRANGE
+            final preconditionalOverrides = [
+              flavorPod.overrideWithValue(flavor),
+            ];
+            // ACT
+            container = ProviderContainer(
+              overrides: [
+                ...preconditionalOverrides,
+              ],
+            );
+          },
+        );
+
+        test(
+          '''
+
+THEN the necessary flavor-independent users-related dependencies should be injected
+├─ AND injecting a single users repository
+├─ AND injecting a single users cubit
+''',
+          () async {
+            // ASSERT
+            expect(
+              container.read(usersRepoPod),
+              isA<UsersRepo>(),
+            );
+            expect(
+              container.read(usersCubitPod),
+              isA<UsersCubit>(),
+            );
+          },
+        );
+
+        switch (flavor) {
+          case Flavor.dev:
+          case Flavor.prod:
+            test(
+              '''
+
+THEN the necessary users-related dependencies for the ${flavor.tag} flavor should be injected
+├─ AND injecting a single Dio HTTP client
+├─ AND injecting a single REST-based users remote data source
+''',
+              () async {
+                // ASSERT
+                expect(
+                  container.read(usersDioPod),
+                  isA<Dio>(),
+                );
+                expect(
+                  container.read(usersRDSPod),
+                  isA<rest.UsersRDSImp>(),
                 );
               },
             );
-
+            break;
+          case Flavor.stg:
             test(
               '''
 
-THEN a single users remote data source should be injected
-AND a single users repo should be injected
-AND a single users cubit should be injected
+THEN the necessary users-related dependencies for the ${flavor.tag} flavor should be injected
+├─ AND injecting a single GraphQL client
+├─ AND injecting a single GraphQL-based users remote data source
 ''',
               () async {
                 // ASSERT
-                expect(getIt.isRegistered<UsersRDS>(), isTrue);
-                expect(getIt.isRegistered<UsersRepo>(), isTrue);
-                expect(getIt.isRegistered<UsersCubit>(), isTrue);
+                expect(
+                  container.read(usersGQLClientPod),
+                  isA<GraphQLClient>(),
+                );
+                expect(
+                  container.read(usersRDSPod),
+                  isA<gql.UsersRDSImp>(),
+                );
               },
             );
-
-            test(
-              '''
-
-THEN a single users cubit should be available
-''',
-              () async {
-                // ASSERT
-                expect(getIt.get<UsersCubit>(), isNotNull);
-              },
-            );
-
-            if (flavor == Flavor.dev || flavor == Flavor.prod) {
-              test(
-                '''
-
-THEN a single HTTP client should be injected
-''',
-                () async {
-                  // ASSERT
-                  expect(getIt.isRegistered<Dio>(), isTrue);
-                },
-              );
-            } else if (flavor == Flavor.stg) {
-              test(
-                '''
-
-THEN a single GraphQL client should be injected
-''',
-                () async {
-                  // ASSERT
-                  expect(getIt.isRegistered<GraphQLClient>(), isTrue);
-                },
-              );
-            }
-          },
-        );
-      }
-    },
-  );
+            break;
+        }
+      },
+    );
+  }
 }


### PR DESCRIPTION
# Description

Riverpod offers directional dependency injection, which means a safer codebase. Plus, it also allows injecting multiple instances of the same type, a handy feature for complex use cases.

Riverpod can replace both `get_it` and `provider` since it is widget-tree-independent and can be easily scoped.

# Type of Change

<!--- Uncomment in all the lines that apply: -->

- 🛠️ Bug fix
- 📝 Documentation
- 🧹 Code refactor
- 🧪 Test

<!-- - ✅ Build configuration change -->
<!-- - 🗑️ Chore -->
<!-- - ⚡️ Continuous integration -->
<!-- - ✨ New feature -->
<!-- - 🚀 Performance improvement -->
<!-- - ⏪ Reversion -->
<!-- - 🎭 Style -->

<!--- Uncomment the following line only if the pull request includes a FIX or a FEATURE with no backwards compatibility -->

<!-- ❌❌❌ Breaking change ❌❌❌ -->
